### PR TITLE
Fixed a bug with epsilon lookaheads.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+*.swp

--- a/bin/jscc
+++ b/bin/jscc
@@ -1561,6 +1561,8 @@ function lalr1_closure( s )
 			
 			if( j == states[s].epsilon.length )			
 				states[s].epsilon.push( closure[i] );
+			else
+				states[s].epsilon[j] = closure[i];
 
 			closure.splice( i, 1 );
 		}


### PR DESCRIPTION
In the function lalr1_closure, when a partition compares equal to a currently existing state, it is made to be exactly that state. However, at the point at which the partition occurs after the first time, new lookaheads may have become apparent, and these are not copied across correctly to the epsilon property of the new state. Here is a test grammar which illustrates the bug: https://gist.github.com/jf89/2f9afeee96e0ffe456ab.

Note that the grammar should accept the strings:
A
AC
(A)
(AC)
(A)C
(AC)C
((A))
((AC))
((A)C)
((AC)C)

However, the bug in the code causes the cases where no C precedes a ) to fail, as the ) symbol is not copied over to epsilon lookaheads correctly.
